### PR TITLE
implement shot timer

### DIFF
--- a/firmware/config.py
+++ b/firmware/config.py
@@ -33,7 +33,8 @@ class Config:
                  laser_cal: int = 0.157,
                  save_readings: bool = False,
                  low_precision: bool = False,
-                 calib: dict = None):
+                 calib: dict = None,
+                 timer: int = 5):
         self.timeout = timeout
         self.angles = angles
         self.units = units
@@ -51,6 +52,7 @@ class Config:
             self.calib: Optional[Calibration] = Calibration.from_dict(calib)
         else:
             self.calib: Optional[Calibration] = None
+        self.timer = timer
 
     def as_dict(self):
         dct = {}

--- a/firmware/config.py
+++ b/firmware/config.py
@@ -34,7 +34,7 @@ class Config:
                  save_readings: bool = False,
                  low_precision: bool = False,
                  calib: dict = None,
-                 timer: int = 5):
+                 timer: int = 0):
         self.timeout = timeout
         self.angles = angles
         self.units = units

--- a/firmware/docs/source/index.rst
+++ b/firmware/docs/source/index.rst
@@ -37,7 +37,7 @@ Measure Mode (to take readings)
 
 Press **A** to take a reading. You will get an error if the device is not already :ref:`calibrated <Sensors>`.
 You can choose either a short press of **A** (the reading is taken just after the button is released) or a long press
-of **A** (the reading is taken after a countdown timer, which defaults to 5 seconds and can be configured).
+of **A** (the reading is taken after about a second, or can trigger a countdown timer which can be configured).
 Play with each mode and see what suits you.
 
 If the reading is successful you will see three numbers on the screen: 
@@ -72,6 +72,11 @@ be stored in a separate trip file.
 
 There is a battery level indicator on the bottom right of the screen. If you want to save power, turn off the device
 between stations.
+
+When you hold **A** to take a reading, the SAP6 will trigger a timer. The timer mode can be configured to a 0, 3, 5,
+or 10 second countdown. For settings greater than 0, the unit will beep every second until it takes the reading.
+If set to 0, it will take the reading after about a second while the button is still held (this is the normal
+behavior in firmware versions 1.0.2 and prior).
 
 Battery Life
 ------------

--- a/firmware/docs/source/index.rst
+++ b/firmware/docs/source/index.rst
@@ -37,8 +37,8 @@ Measure Mode (to take readings)
 
 Press **A** to take a reading. You will get an error if the device is not already :ref:`calibrated <Sensors>`.
 You can choose either a short press of **A** (the reading is taken just after the button is released) or a long press
-of **A** (the reading is taken once the button has been pressed for a second or so). Play with each mode and see what
-suits you.
+of **A** (the reading is taken after a countdown timer, which defaults to 5 seconds and can be configured).
+Play with each mode and see what suits you.
 
 If the reading is successful you will see three numbers on the screen: 
 .. compass at the top (degrees or grad)

--- a/firmware/measure.py
+++ b/firmware/measure.py
@@ -51,6 +51,12 @@ async def measure(devices: hardware.Hardware, cfg: config.Config, disp: display.
         if btn == "a":
             if click == Button.SINGLE:
                 await asyncio.sleep(0.3)
+            # long click should start timer.
+            # consider making this more sophisticated
+            if click == Button.LONG:
+                for i in range(10):
+                    devices.beep_bip()
+                    await asyncio.sleep(1)
             success = await take_reading(devices, cfg, disp)
         elif btn == "b":
             logger.debug("B pressed")

--- a/firmware/measure.py
+++ b/firmware/measure.py
@@ -52,9 +52,8 @@ async def measure(devices: hardware.Hardware, cfg: config.Config, disp: display.
             if click == Button.SINGLE:
                 await asyncio.sleep(0.3)
             # long click should start timer.
-            # consider making this more sophisticated
             if click == Button.LONG:
-                for i in range(10):
+                for i in range(cfg.timer):
                     devices.beep_bip()
                     await asyncio.sleep(1)
             success = await take_reading(devices, cfg, disp)

--- a/firmware/menu.py
+++ b/firmware/menu.py
@@ -73,6 +73,15 @@ async def menu(devices: hardware.Hardware, cfg: config.Config, disp: display.Dis
                     ("5 minutes", 300),
                 ]
             )),
+            ("Timer", ConfigOptions(
+                name="timer", obj=cfg,
+                options=[
+                    ("0 seconds", 0),
+                    ("3 seconds", 3),
+                    ("5 seconds", 5),
+                    ("10 seconds", 10),
+                ]
+            )),
             ("Distance Units", ConfigOptions(
                 name="units", obj=cfg,
                 options=[


### PR DESCRIPTION
This implements a basic timer (like the "timer" button on the distoX). Hold down A and the unit will count down in seconds. It can be configured to "0" (the previous default behaviour), 3, 5, or 10 seconds from the configuration menu. The default is 5.