### PR TITLE
this shuts off the laser when in the menu view.

### DIFF
--- a/firmware/menu.py
+++ b/firmware/menu.py
@@ -51,6 +51,7 @@ async def menu(devices: hardware.Hardware, cfg: config.Config, disp: display.Dis
     logger.debug("Menu task started")
     gc.collect()
     await asyncio.sleep(0.1)
+    await devices.laser.set_laser(False)
     items = [
         ("Calibrate", [
             ("Sensors", AsyncAction(calibrate.calibrate_sensors)),


### PR DESCRIPTION
having the laser on while fiddling around in the menu can be annoying (I find myself blinded by it reflecting off my hand a lot).

Since the laser is seperately turned on in the calibrate and measure apps, this does not negatively affect any functionality, and probably saves a little battery.