### PR TITLE
Add menu option to disable screen flip

### DIFF
--- a/firmware/app.py
+++ b/firmware/app.py
@@ -188,7 +188,7 @@ class App:
 
     async def flip_monitor(self):
         logger.debug("Starting flip monitor")
-        while True:
+        while self.config.flip_monitor:
             await asyncio.sleep(0.3)
             grav = self.devices.accelerometer.acceleration
             if self.config.calib is not None:

--- a/firmware/config.py
+++ b/firmware/config.py
@@ -34,6 +34,7 @@ class Config:
                  save_readings: bool = False,
                  low_precision: bool = False,
                  calib: dict = None,
+                 flip_monitor: bool = True,
                  timer: int = 5):
         self.timeout = timeout
         self.angles = angles
@@ -52,6 +53,7 @@ class Config:
             self.calib: Optional[Calibration] = Calibration.from_dict(calib)
         else:
             self.calib: Optional[Calibration] = None
+        self.flip_monitor = flip_monitor
         self.timer = timer
 
     def as_dict(self):

--- a/firmware/menu.py
+++ b/firmware/menu.py
@@ -114,7 +114,15 @@ async def menu(devices: hardware.Hardware, cfg: config.Config, disp: display.Dis
                     ("Off", False),
                     ("On", True),
                 ]
-            ))
+            )),
+            ("Flip Monitor", ConfigOptions(
+                #TODO consider allowing "left, right, flip"
+                name="flip_monitor", obj=cfg,
+                options=[
+                    ("Off", False),
+                    ("On", True),
+                ]
+            )),
         ]),
         ("Bluetooth", [
             ("Disconnect", devices.bt.disconnect),


### PR DESCRIPTION
Pretty self-explanatory: I find the monitor flip to be easy to accidentally trigger, so I'd like to disable it.

The good part: if you turn off the setting, it applies without a reboot. the bad part, it will not reapply until you reboot. This could be fixed, but I've elected to not add complexity to app.py for now.

Currently this code is running on my SAP6 and behaves as expected.