### PR TITLE
Fix issue #13

### DIFF
--- a/firmware/app.py
+++ b/firmware/app.py
@@ -1,5 +1,5 @@
 import asyncio
-import time
+import supervisor
 import traceback
 from watchdog import WatchDogMode
 
@@ -96,11 +96,11 @@ class App:
         Shuts down  if double-click on button A
         """
         logger.debug("Quitter task started")
-        lockout = time.monotonic() + 0.5
+        lockout = supervisor.ticks_ms() + 500
         while True:
             await self.devices.button_a.wait(Button.DOUBLE)
             check_mem("double click")
-            if time.monotonic() > lockout:
+            if supervisor.ticks_ms() > lockout:
                 logger.info("Double click detected, quitting")
                 self.shutdown_event.set()
 

--- a/firmware/main.py
+++ b/firmware/main.py
@@ -1,6 +1,7 @@
 import seeed_xiao_nrf52840
 # noinspection PyPackageRequirements
 import digitalio
+import supervisor
 import time
 import asyncio
 import traceback
@@ -40,8 +41,8 @@ def double_click_start() -> bool:
         # wait for release
         while not button_a.value:
             time.sleep(0.03)
-        dbl_click_interval_expired = time.monotonic() + 1.0
-        while time.monotonic() < dbl_click_interval_expired:
+        dbl_click_interval_expired = supervisor.ticks_ms()+1000
+        while supervisor.ticks_ms() < dbl_click_interval_expired:
             if not button_a.value:
                 # button been pressed in relevant time
                 return True


### PR DESCRIPTION
Replaces `time.monotonic()` with `supervisor.ticks_ms()`